### PR TITLE
chore (dockerfile) updated dockerfile to 3.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7@sha256:92251458088c638061cda8fd8b403b76d661a4dc6b7ee71b6affcf1872557b2b
+FROM alpine:3.10.3@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a
 
 LABEL maintainer "Leonardo Gatica <lgatica@protonmail.com>"
 


### PR DESCRIPTION
Updated docker to latest 3.10.3 release of Alpine. Results in version 8.1_p1-r0 of Openssh-client instead of 7.5_p1-r10